### PR TITLE
Add Jenkinsfile for auto build discovery

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,28 @@
+#!groovy
+node('clang') {
+  stage('Checkout') {
+    checkout([
+      $class: 'GitSCM',
+      branches: scm.branches,
+      extensions: scm.extensions + [[$class: 'CleanBeforeCheckout']],
+      userRemoteConfigs: scm.userRemoteConfigs
+    ])
+  }
+  stage('Build') {
+    echo 'Compiling'
+    sh 'CXX=clang++ cmake .'
+    sh 'make'
+    echo 'Build Complete!'
+  }
+  stage('Test') {
+    parallel 'unit tests': {
+      //sh 'make test'
+      echo 'Unit Tests Complete!'
+    }, 'acceptance tests': {
+      echo 'Acceptance Tests Complete!'
+    }
+  }
+  stage('Release') {
+    echo 'Release Package Created!'
+  }
+}


### PR DESCRIPTION
Prior to this commit we were required to manaully create Jenkins jobs
for building and testing this repository. This commit adds a shell of a
Jenkinsfile that enumerates the various stages in the pipeline and
successfully executes the Checkout and Build stages. The Test and
Release stages are merely placeholders.