### PR TITLE
Change Jenkinsfile to out-of-source build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,11 +7,15 @@ node('clang') {
       extensions: scm.extensions + [[$class: 'CleanBeforeCheckout']],
       userRemoteConfigs: scm.userRemoteConfigs
     ])
+    try {
+      sh 'rm -rf build'
+    } finally {}
   }
   stage('Build') {
     echo 'Compiling'
-    sh 'CXX=clang++ cmake .'
-    sh 'make'
+    sh 'mkdir build'
+    sh 'CXX=clang++ cmake -Bbuild -H.'
+    sh 'cd build && make'
     echo 'Build Complete!'
   }
   stage('Test') {


### PR DESCRIPTION
Prior to this commit Jenkins would build the binaries in the source tree
alongside the source files, generally acknowledged to be a bad practice.
This commit alters the Jenkins build to create those binaries in a
separate `build` directory so that the binaries can be referenced by
unit and acceptance tests in a standard location.