### PR TITLE
remove attempt to build matlab from cmake

### DIFF
--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -8,10 +8,6 @@ add_library( plog_encode MODULE plog_encode.cpp )
 target_link_libraries ( plog_encode plog dl )
 set_target_properties( plog_encode PROPERTIES PREFIX "transcode." )
 
-add_library( matlab MODULE matlab.cpp )
-target_link_libraries ( matlab plog dl )
-set_target_properties( matlab PROPERTIES PREFIX "transcode." )
-
 set ( HDF5_FOUND FALES )
 if ( ${HDF5_FOUND} )
     include_directories( ${HDF5_INCLUDE_DIRS} )


### PR DESCRIPTION
Prior to this commit cmake was attempting to build matlab plugins that
had been removed in f60dcec. This commit removes those components from
the cmake build manifest so that we don't try to build a non-existant
plugin.