### PR TITLE
Rearrange catch_main()

### DIFF
--- a/cmdline/encode.cpp
+++ b/cmdline/encode.cpp
@@ -26,18 +26,16 @@ static logger log( "encode" );
 
 std::map< std::string, boost::shared_ptr<encode::plugin> > map;
 
-po::options_description load() {
+void load( po::options_description& options ) {
 
-    po::options_description options( "Encoder Plugins:" );
-
-    // We have some hard linked plugins.  This makes important ones and that
     // have no extra dependencies always available, even if the plugin path is
     // misconfigured.  It also makes the query options appear first in the help
     // screen, also useful.
     dll::shared_library self( dll::program_location() );
     for ( std::string plugname: { "list", "dump" } ) {
-        auto plugin_factory = 
-            self.get_alias<boost::shared_ptr<encode::plugin>()>( plugname + "_plugin" );
+        auto plugin_factory =
+            self.get_alias<boost::shared_ptr<encode::plugin>()>(
+                    plugname + "_plugin" );
         auto plugin = plugin_factory();
         options.add( plugin->options() );
         encode::map.emplace( plugname, plugin );
@@ -53,11 +51,13 @@ po::options_description load() {
         plugdir = plugdir / "encode";
 
         if ( !fs::exists( plugdir ) ) {
-            BOOST_LOG_SEV( log, severity::debug1 ) << "skipping non-existing plugin path " << plugdir;
+            BOOST_LOG_SEV( log, severity::debug1 )
+                << "skipping non-existing plugin path " << plugdir;
             continue;
         }
 
-        BOOST_LOG_SEV( log, severity::debug1 ) << "searching " << plugdir << " for encoder plugins";
+        BOOST_LOG_SEV( log, severity::debug1 )
+            << "searching " << plugdir << " for encoder plugins";
         static std::regex is_plugin( R"(.*encode\.(.+)\.so)" );
         for ( fs::directory_entry& lib: fs::directory_iterator(plugdir) ) {
             std::cmatch match;
@@ -66,30 +66,29 @@ po::options_description load() {
                 std::string plugname = match[1];
 
                 if ( encode::map.count(plugname) ) {
-                    BOOST_LOG_SEV( log, severity::debug2 ) << "encoder \"" << plugname << "\"already loaded";
+                    BOOST_LOG_SEV( log, severity::debug2 )
+                        << "encoder \"" << plugname << "\"already loaded";
                     continue;
                 }
 
                 try {
-                    boost::shared_ptr<encode::plugin> plugin = 
+                    boost::shared_ptr<encode::plugin> plugin =
                         dll::import<encode::plugin>( lib.path(), "encoder" );
-                    BOOST_LOG_SEV( log, severity::debug1 ) << "loaded encoder from " << lib.path();
+                    BOOST_LOG_SEV( log, severity::debug1 )
+                        << "loaded encoder from " << lib.path();
                     po::options_description opt = plugin->options();
                     options.add( opt );
                     encode::map.emplace( plugname, plugin );
                 } catch ( std::runtime_error& ) {
-                    BOOST_LOG_SEV( log, severity::debug2 ) 
+                    BOOST_LOG_SEV( log, severity::debug2 )
                         << lib.path() << " provides no encoder; symbols not found";
                 }
             } else {
-                BOOST_LOG_SEV( log, severity::debug2 ) 
+                BOOST_LOG_SEV( log, severity::debug2 )
                     << lib.path() << " provides no encoder; filename mismatch";
             }
         }
     }
-
-    return options;
-
 }
 
 }} // namespace polysync::encode

--- a/cmdline/transcode.cpp
+++ b/cmdline/transcode.cpp
@@ -36,79 +36,86 @@ std::ostream& operator<<(std::ostream& os, const std::vector<fs::path>& paths) {
 
 } // namespace std
 
-namespace options {
+// The command line parse is complicated because the plugins are allowed to
+// add options, and finding the plugins themselves require an opportunity
+// to set paths to their location before loading.
+//
+// There are three stages:
+// 1) Bootstrap: Configure the console spew because this will affect the second
+//    stage.  Also, accept more plugin paths.
+// 2) Input/Output: Parse the positional arguments (input and encoder) to
+//    identify the encoder's name.  Filters are also parsed in this stage.  Filter
+//    options cannot be duplicated; take care in the filter plugins that the
+//    option names are not reserved by some other plugin.
+// 3) Encoder: The final parse enables only the options from the chosen encoder.
+//    This allows duplicate options between different encoder plugins, which will
+//    be common (like output file name).
+//
+// The encoders are handled similarly to subcommands (like git does).  This
+// pattern was originally described for boost::program_options by
+// http://stackoverflow.com/questions/15541498/how-to-implement-subcommands-using-boost-program-options
 
-po::options_description console() {
-    po::options_description opts( "General Options" );
-    opts.add_options()
-        ( "help,h", "print this help message" )
-        ( "verbose,v", po::value<std::string>()->default_value("info"),
-          "debug level" )
-        ( "plain,p", "remove color from console formatting" )
-        ;
-    return opts;
-}
+class cmdline_parser {
 
-po::options_description positional() {
-    po::options_description opts;
-    opts.add_options()
-        ( "input", po::value<std::vector<fs::path>>(), "Input file" )
-        ( "encoder", po::value<std::string>()->default_value("list"),
-          "Output encoder" )
-        ( "subargs", po::value<std::vector<std::string>>(),
-          "Encoder arguments" )
-        ;
-    return opts;
-}
+public:
 
-} // namespace options
-
-int print_help( const po::options_description& helpline ) {
-
-    std::cout << polysync::format->header( "PolySync Transcoder" )
-              << std::endl << std::endl;
-    std::cout << "Usage:" << std::endl;
-    std::cout << "\ttranscode [options] <input-file> <encoder> "
-              << "[encoder-options]" << std::endl;
-    std::cout << helpline << std::endl << std::endl;
-    return ps::status::ok;
-}
-
-
-int catch_main( int ac, char* av[] ) {
-
-    logger log( "transcode" );
-
-    // The command line parse is complicated because the plugins are allowed to
-    // add options, and finding the plugins themselves require an opportunity
-    // to set paths to their location before loading.
-    //
-    // There are three stages:
-    // 1) Configure the console spew because this will affect the second stage.
-    // 2) Parse the positional arguments (input and encoder) to identify the
-    //    encoder's name.  Filters are also parsed in this stage.  Filter
-    //    options cannot be duplicated; take care in the filter plugins that
-    //    the option names are not reserved by some other plugin.
-    // 3) The final parse enables only the options from the chosen encoder.  This
-    //    allows duplicate options between different encoder plugins, which will
-    //    be common (like output file name).
-    //
-    // The encoders are handled similarly to subcommands (like git does).  This
-    // pattern was originally described for boost::program_options by
-    // http://stackoverflow.com/questions/15541498/how-to-implement-subcommands-using-boost-program-options
+    void bootstrap( int ac, char* av[] );
+    po::parsed_options configure_input_output( int ac, char* av[] );
+    void configure_encoder( po::parsed_options& );
+    void print_usage();
 
     // All the stages accumulate results into one container of arguments,
     // called cmdline_args.
     po::variables_map cmdline_args;
 
-    po::options_description console_opts = options::console();
+protected:
 
-    // Stage 1:  Console options
-    po::parsed_options stage1_parse = po::command_line_parser( ac, av )
-        .options(console_opts)
-        .allow_unregistered() // Pass through everything except console_opts
+    logger log { "cmdline" };
+
+    po::options_description bootstrap_options { "Bootstrap Options" };
+    po::options_description toml_options { "Type Description Options" };
+    po::options_description filter_options { "Filter Plugins" };
+    po::options_description encode_options { "Encoder Plugins" };
+
+};
+
+void cmdline_parser::print_usage() {
+
+    if ( cmdline_args.count("help") ) {
+
+        po::options_description helpline;
+        helpline.add( bootstrap_options )
+                // .add( toml_options ) // These are currently empty
+                .add( filter_options )
+                .add( encode_options );
+
+        std::cout << polysync::format->header( "PolySync Transcoder" )
+                  << std::endl << std::endl;
+        std::cout << "Usage:" << std::endl;
+        std::cout << "\ttranscode [options] <input-file> <encoder> "
+                  << "[encoder-options]" << std::endl;
+        std::cout << helpline << std::endl << std::endl;
+
+        exit( ps::status::ok );
+    }
+}
+
+void cmdline_parser::bootstrap( int ac, char* av[] ) {
+
+    // Stage 1: Bootstrap options to configure plugin paths and debug level
+
+    bootstrap_options.add_options()
+        ( "help,h", "print this help message" )
+        ( "verbose,v", po::value<std::string>()->default_value("info"),
+          "debug level [ info verbose debug1 debug2 ]" )
+        ( "plain,p", "remove color from console formatting" )
+        ;
+
+    po::parsed_options parse_results = po::command_line_parser( ac, av )
+        .options(bootstrap_options)
+        .allow_unregistered() // Pass through everything except bootstrap options
         .run();
-    po::store( stage1_parse, cmdline_args );
+    po::store( parse_results, cmdline_args );
     po::notify( cmdline_args );
 
     // Set the debug and console format options right away so log messages in
@@ -122,41 +129,51 @@ int catch_main( int ac, char* av[] ) {
 
     // Check that the environment is set up so the plugins do not have to.
     char* libdir = std::getenv( "POLYSYNC_TRANSCODER_LIB" );
-    if ( libdir == nullptr )
+    if ( libdir == nullptr ) {
         throw polysync::error(
                 "POLYSYNC_TRANSCODER_LIB unset; cannot find TOML or plugins");
+    }
 
     // Find all the runtime resources and load them
-    po::options_description toml_opts = ps::toml::load();
-    po::options_description filter_opts = ps::filter::load();
-    po::options_description encode_opts = ps::encode::load();
+    ps::toml::load( toml_options );
+    ps::filter::load( filter_options );
+    ps::encode::load( encode_options );
 
-    // Build the help spew.  toml_opts is omitted because, for now, it is
-    // actually empty.
-    po::options_description helpline;
-    helpline.add( console_opts ).add( filter_opts ).add( encode_opts );
+}
 
-    if ( cmdline_args.count("help") )
-        return print_help( helpline );
+po::parsed_options cmdline_parser::configure_input_output( int ac, char* av[] ) {
 
     // Stage 2: determine the filters and encoder name
     po::positional_options_description posdesc;
-    posdesc.add( "input", 1 ).add( "encoder", 1 ).add( "subargs", -1 );
+    posdesc.add( "input", 1 ).add( "encoder", 1 ).add( "encoder_args", -1 );
 
-    po::options_description stage2_cmdline;
-    po::options_description positional_opts = options::positional();
-    stage2_cmdline.add( console_opts ).add( filter_opts ).add( positional_opts );
+    po::options_description positional_options;
+    positional_options.add_options()
+        ( "input", po::value< std::vector<fs::path> >(), "Input file" )
+        ( "encoder", po::value<std::string>()->default_value( "list" ),
+          "Output encoder" )
+        ( "encoder_args", po::value< std::vector<std::string> >(),
+          "Encoder arguments" )
+        ;
 
-    po::parsed_options stage2_parse = po::command_line_parser( ac, av )
-        .options(stage2_cmdline)
+    po::options_description options;
+    options.add( bootstrap_options )
+           .add( toml_options )
+           .add( filter_options )
+           .add( positional_options )
+        ;
+
+    po::parsed_options parse_results = po::command_line_parser( ac, av )
+        .options(options)
         .positional(posdesc)
-        .allow_unregistered() // Pass through encoder args for stage3
+        .allow_unregistered() // Pass through encoder args for
         .run();
-    po::store( stage2_parse, cmdline_args );
+    po::store( parse_results, cmdline_args );
     po::notify( cmdline_args );
 
-    if ( !cmdline_args.count("input") )
+    if ( !cmdline_args.count("input") ) {
         throw ps::error( "no input file" ) << ps::status::bad_input;
+    }
 
     std::string encoder = cmdline_args["encoder"].as<std::string>();
     if ( !ps::encode::map.count( encoder ) ) {
@@ -164,31 +181,48 @@ int catch_main( int ac, char* av[] ) {
         exit( ps::status::no_plugin );
     }
 
-    // The filter arguments are parsed.  Build a list of active filters.
-    std::vector<ps::filter::type> filters;
-    for ( auto pair: ps::filter::map ) {
-        ps::filter::type pred = pair.second->predicate( cmdline_args );
-        if ( pred )
-            filters.push_back(pred);
-    }
+    return parse_results;
+}
+
+void cmdline_parser::configure_encoder( po::parsed_options& parse_results ) {
 
     // Stage 3:
-    // At this point, all the general options are parsed, as are the positional
+    // Alt this point, all the general options are parsed, as are the positional
     // arguments for input and encoder name. Build a final stage 3 parse that is
     // informed by the specific encoder requested.
 
-    po::options_description encoder_opts = ps::encode::map.at( encoder )->options();
-    po::options_description stage3_cmdline;
-    stage3_cmdline.add( encoder_opts );
-
+    std::string encoder = cmdline_args["encoder"].as<std::string>();
+    po::options_description options = ps::encode::map.at( encoder )->options();
     std::vector<std::string> encoder_args =
-        po::collect_unrecognized( stage2_parse.options, po::include_positional );
+        po::collect_unrecognized( parse_results.options, po::include_positional );
 
     // Parse again, with now with encoder options
     po::store( po::command_line_parser( encoder_args )
-            .options( stage3_cmdline )
+            .options( options )
             .run(), cmdline_args );
-    po::notify(cmdline_args);
+    po::notify( cmdline_args );
+}
+
+
+int catch_main( int ac, char* av[] ) {
+
+    logger log { "transcode" };
+
+    cmdline_parser parse;
+
+    parse.bootstrap( ac, av );
+    parse.print_usage();
+    po::parsed_options parse_results = parse.configure_input_output( ac, av );
+    parse.configure_encoder( parse_results );
+
+    std::vector<ps::filter::type> filters;
+    // The filter arguments are parsed.  Build a list of active filters.
+    for ( auto pair: ps::filter::map ) {
+        ps::filter::type pred = pair.second->predicate( parse.cmdline_args );
+        if ( pred ) {
+            filters.push_back(pred);
+        }
+    }
 
     ps::descriptor::catalog.emplace( "log_record", ps::descriptor::describe<plog::log_record>::type() );
     ps::descriptor::catalog.emplace( "msg_header", ps::descriptor::describe<plog::msg_header>::type() );
@@ -206,23 +240,26 @@ int catch_main( int ac, char* av[] ) {
     visit.type_support.connect( []( plog::type_support t ) {
             // Don't bother registering detectors for types if do not have the
             // descriptor.
-            if ( ps::descriptor::catalog.count(t.name) )
+            if ( ps::descriptor::catalog.count(t.name) ) {
                  ps::detector::catalog.push_back(ps::detector::type { "msg_header",
                     { { "type", t.type } },
                     t.name } );
-            plog::type_support_map.emplace( t.type, t.name );
+                 }
+                 plog::type_support_map.emplace( t.type, t.name );
             } );
 
-    ps::encode::map.at( encoder )->connect( cmdline_args, visit );
+    std::string encoder = parse.cmdline_args["encoder"].as<std::string>();
+    ps::encode::map.at( encoder )->connect( parse.cmdline_args, visit );
 
     // The observers are finally all set up.  Here, we finally do the computation!
     // Double iterate over files from the command line, and records in each file.
-    for ( fs::path path: cmdline_args["input"].as<std::vector<fs::path>>() )
+    for ( fs::path path: parse.cmdline_args["input"].as< std::vector<fs::path> >() )
     {
         try {
             std::ifstream st( path.c_str(), std::ifstream::binary );
-            if ( !st )
+            if ( !st ) {
                 throw polysync::error( "cannot open file" );
+            }
 
             // Construct the next reader in the file list
             plog::decoder decoder( st );
@@ -233,11 +270,14 @@ int catch_main( int ac, char* av[] ) {
 
             decoder.decode( head );
             visit.log_header( head );
-            for ( const plog::type_support& type: head.type_supports )
+
+            for ( const plog::type_support& type: head.type_supports ) {
                 visit.type_support( type );
+            }
+
             for ( const plog::log_record& rec: decoder ) {
-                if ( std::all_of(filters.begin(), filters.end(),
-                      [&rec]( const ps::filter::type& pred ) { return pred(rec); }) ) {
+                if ( std::all_of( filters.begin(), filters.end(),
+                      [&rec]( const ps::filter::type& pred ) { return pred(rec); } ) ) {
                     BOOST_LOG_SEV( log, severity::verbose ) << rec;
                     polysync::node top( "log_record", decoder.deep(rec) );
                     visit.record(top);
@@ -261,8 +301,10 @@ int main( int ac, char* av[] ) {
     } catch ( const ps::error& e ) {
         // Print any context provided by the exception.
         std::cerr << polysync::format->error( "Transcoder abort: " ) << e;
-        if ( const ps::status* stat = boost::get_error_info<ps::exception::status>(e) )
+        if ( const ps::status* stat =
+                boost::get_error_info<ps::exception::status>(e) ) {
             exit( *stat );
+        }
     } catch ( const po::error& e ) {
         std::cerr << polysync::format->error( "Transcoder abort: " )
                   << e.what() << std::endl;

--- a/polysync/plugin.hpp
+++ b/polysync/plugin.hpp
@@ -12,7 +12,7 @@
 namespace po = boost::program_options;
 namespace fs = boost::filesystem;
 
-namespace polysync { 
+namespace polysync {
 
 namespace encode {
 
@@ -21,7 +21,7 @@ extern po::options_description options();
 // Visitation points.
 struct visitor {
 
-    template <typename T> 
+    template <typename T>
     using callback = boost::signals2::signal<void (T)>;
 
     callback< plog::decoder& > open; // New plog file was opened.
@@ -40,7 +40,7 @@ struct plugin {
     virtual void connect( const po::variables_map&, visitor& ) = 0;
 };
 
-extern po::options_description load();
+extern void load( po::options_description& );
 extern std::map< std::string, boost::shared_ptr<encode::plugin> > map;
 
 } // namespace encode
@@ -51,10 +51,10 @@ using type = std::function<bool (const plog::log_record&)>;
 
 struct plugin {
     virtual po::options_description options() const = 0;
-    virtual type predicate( const po::variables_map& ) const = 0;  
+    virtual type predicate( const po::variables_map& ) const = 0;
 };
 
-extern po::options_description load(); 
+extern void load( po::options_description& );
 extern std::map< std::string, boost::shared_ptr<filter::plugin> > map;
 
 } // namespace filter

--- a/polysync/toml.hpp
+++ b/polysync/toml.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
-namespace polysync { namespace toml { 
+namespace polysync { namespace toml {
 
 namespace po = boost::program_options;
 
-extern po::options_description load();  
+extern void load( po::options_description& );
 
 }} // namespace polysync::toml
 


### PR DESCRIPTION
Prior to this commit, catch_main() in transcode.cpp executing linearly
with some of the options defined inline.  This commit moved some of the
self contained blocks into separate functions, in an attempt to make the
necessarily complicated parser easier to read.  Note that most of the
options are already set in their own functions in plugins as part of the plugin
interface, and never were in catch_main().  Whether this commit makes the
function catch_main() easier to read or not is subjective matter, and
does diverge somewhat from the style established by the reference
documentation of boost::program_options.